### PR TITLE
Update deps to work on io.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
   "author": "max ogden",
   "license": "BSD",
   "dependencies": {
-    "requestdb": "0.1.0",
-    "request": "^2.48.0",
-    "through2": "0.4.2",
+    "requestdb": "^0.1.2",
     "debug": "0.7.4",
     "minimist": "0.0.10",
-    "ndjson": "^1.2.3"
+    "ndjson": "^1.2.3",
+    "request": "^2.48.0",
+    "through2": "0.4.2",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
Updates requestdb, so level will compile  on io.js and also xtend because of a deprecation notice.
